### PR TITLE
Better collision context

### DIFF
--- a/crates/avian2d/examples/custom_collider.rs
+++ b/crates/avian2d/examples/custom_collider.rs
@@ -51,7 +51,15 @@ impl CircleCollider {
 }
 
 impl AnyCollider for CircleCollider {
-    fn aabb(&self, position: Vector, _rotation: impl Into<Rotation>) -> ColliderAabb {
+    type Context = ();
+
+    fn aabb(
+        &self,
+        position: Vector,
+        _rotation: impl Into<Rotation>,
+        _entity: Entity,
+        _context: &Self::Context,
+    ) -> ColliderAabb {
         ColliderAabb::new(position, Vector::splat(self.radius))
     }
 

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -153,7 +153,7 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
             let entity_ref = world.entity(entity);
             let collider = entity_ref.get::<C>().unwrap();
 
-            let context = {
+            let aabb = {
                 let mut context_state = {
                     let cell = world.as_unsafe_world_cell_readonly();
                     // SAFETY: No other code takes a ref to this resource,
@@ -170,14 +170,14 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
                         type_name::<C::Context>()
                     )
                 });
+                let context = context_state.0.get(&world);
 
-                context_state.0.get(&world)
+                entity_ref
+                    .get::<ColliderAabb>()
+                    .copied()
+                    .unwrap_or(collider.aabb(Vector::ZERO, Rotation::default(), entity, &context))
             };
 
-            let aabb = entity_ref
-                .get::<ColliderAabb>()
-                .copied()
-                .unwrap_or(collider.aabb(Vector::ZERO, Rotation::default(), entity, &context));
             let density = entity_ref
                 .get::<ColliderDensity>()
                 .copied()

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -99,6 +99,9 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
             app.insert_resource(ColliderRemovalSystem(collider_removed_id));
         }
 
+        let context_state = SystemState::new(app.world_mut());
+        app.insert_resource(ContextState::<C>(context_state));
+
         let hooks = app.world_mut().register_component_hooks::<C>();
 
         // Initialize missing components for colliders.

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -2,13 +2,18 @@
 //!
 //! See [`ColliderBackendPlugin`].
 
+use std::any::type_name;
 use std::marker::PhantomData;
 
 use crate::{broad_phase::BroadPhaseSet, prelude::*, prepare::PrepareSet, sync::SyncConfig};
 #[cfg(all(feature = "bevy_scene", feature = "default-collider"))]
 use bevy::scene::SceneInstance;
 use bevy::{
-    ecs::{intern::Interned, schedule::ScheduleLabel, system::SystemId},
+    ecs::{
+        intern::Interned,
+        schedule::ScheduleLabel,
+        system::{StaticSystemParam, SystemId, SystemState},
+    },
     prelude::*,
 };
 
@@ -85,6 +90,9 @@ impl<C: ScalableCollider> Default for ColliderBackendPlugin<C> {
 
 impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
     fn build(&self, app: &mut App) {
+        #[derive(Resource)]
+        struct ContextState<C: ScalableCollider>(SystemState<C::Context>);
+
         // Register the one-shot system that is run for all removed colliders.
         if !app.world().contains_resource::<ColliderRemovalSystem>() {
             let collider_removed_id = app.world_mut().register_system(collider_removed);
@@ -142,10 +150,28 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
             let entity_ref = world.entity(entity);
             let collider = entity_ref.get::<C>().unwrap();
 
-            let aabb = entity_ref
-                .get::<ColliderAabb>()
-                .copied()
-                .unwrap_or(collider.aabb(Vector::ZERO, Rotation::default(), None));
+            let aabb = {
+                let mut context_state = {
+                    // SAFETY: I don't think this is safe, since we're getting a readonly cell
+                    let cell = world.as_unsafe_world_cell_readonly();
+                    // SAFETY: no other code references this resource
+                    // and `ContextState` is not publicly visible,
+                    // so `context` is unable to fetch access to this resource
+                    unsafe { cell.get_resource_mut::<ContextState<C>>() }
+                }
+                .unwrap_or_else(|| {
+                    panic!(
+                        "context state for `{}` was removed",
+                        type_name::<C::Context>()
+                    )
+                });
+                let context = context_state.0.get(&world);
+
+                entity_ref
+                    .get::<ColliderAabb>()
+                    .copied()
+                    .unwrap_or(collider.aabb(Vector::ZERO, Rotation::default(), entity, &context))
+            };
             let density = entity_ref
                 .get::<ColliderDensity>()
                 .copied()
@@ -154,7 +180,7 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
             let mass_properties = if entity_ref.get::<Sensor>().is_some() {
                 ColliderMassProperties::ZERO
             } else {
-                collider.mass_properties(density.0, None)
+                collider.mass_properties(density.0)
             };
 
             world.commands().entity(entity).try_insert((
@@ -254,7 +280,7 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
                     if let Ok(mut mass_properties) = body_query.get_mut(collider_parent.0) {
                         // Update collider mass props.
                         *collider_mass_properties =
-                            collider.mass_properties(density.max(Scalar::EPSILON), None);
+                            collider.mass_properties(density.max(Scalar::EPSILON));
 
                         // If the collider mass properties are zero, there is nothing to add.
                         if *collider_mass_properties == ColliderMassProperties::ZERO {
@@ -533,8 +559,8 @@ fn pretty_name(name: Option<&Name>, entity: Entity) -> String {
 fn update_aabb<C: AnyCollider>(
     mut colliders: Query<
         (
+            Entity,
             &C,
-            Option<&C::Context>,
             &mut ColliderAabb,
             &Position,
             &Rotation,
@@ -560,14 +586,15 @@ fn update_aabb<C: AnyCollider>(
     narrow_phase_config: Res<NarrowPhaseConfig>,
     length_unit: Res<PhysicsLengthUnit>,
     time: Res<Time>,
+    context: StaticSystemParam<'_, '_, C::Context>,
 ) {
     let delta_secs = time.delta_seconds_adjusted();
     let default_speculative_margin = length_unit.0 * narrow_phase_config.default_speculative_margin;
     let contact_tolerance = length_unit.0 * narrow_phase_config.contact_tolerance;
 
     for (
+        entity,
         collider,
-        context,
         mut aabb,
         pos,
         rot,
@@ -588,7 +615,7 @@ fn update_aabb<C: AnyCollider>(
 
         if speculative_margin <= 0.0 {
             *aabb = collider
-                .aabb(pos.0, *rot, context)
+                .aabb(pos.0, *rot, entity, &context)
                 .grow(Vector::splat(contact_tolerance + collision_margin));
             continue;
         }
@@ -644,7 +671,7 @@ fn update_aabb<C: AnyCollider>(
         // Compute swept AABB, the space that the body would occupy if it was integrated for one frame
         // TODO: Should we expand the AABB in all directions for speculative contacts?
         *aabb = collider
-            .swept_aabb(start_pos.0, start_rot, end_pos, end_rot, context)
+            .swept_aabb(start_pos.0, start_rot, end_pos, end_rot, entity, &context)
             .grow(Vector::splat(collision_margin));
     }
 }
@@ -726,7 +753,6 @@ pub(crate) fn update_collider_mass_properties<C: AnyCollider>(
             &mut PreviousColliderTransform,
             &ColliderParent,
             Ref<C>,
-            Option<&C::Context>,
             &ColliderDensity,
             &mut ColliderMassProperties,
         ),
@@ -746,7 +772,6 @@ pub(crate) fn update_collider_mass_properties<C: AnyCollider>(
         mut previous_collider_transform,
         collider_parent,
         collider,
-        context,
         density,
         mut collider_mass_properties,
     ) in &mut colliders
@@ -762,8 +787,7 @@ pub(crate) fn update_collider_mass_properties<C: AnyCollider>(
             previous_collider_transform.0 = *collider_transform;
 
             // Update collider mass props.
-            *collider_mass_properties =
-                collider.mass_properties(density.max(Scalar::EPSILON), context);
+            *collider_mass_properties = collider.mass_properties(density.max(Scalar::EPSILON));
 
             // Add new collider mass props to the body's mass props.
             mass_properties += collider_mass_properties.transformed_by(collider_transform);

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -107,7 +107,7 @@ pub trait AnyCollider: Component {
     ///     }
     /// }
     /// ```
-    type Context: ReadOnlySystemParam;
+    type Context: for<'w, 's> ReadOnlySystemParam<Item<'w, 's>: Send + Sync>;
 
     /// Computes the [Axis-Aligned Bounding Box](ColliderAabb) of the collider
     /// with the given position and rotation.

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -65,9 +65,7 @@ pub trait AnyCollider: Component {
     // /// ```
     // ///
     // /// This allows access to `MyColliderContext` in collider computations.
-    type Context: ReadOnlySystemParam
-    where
-        for<'w, 's> <Self::Context as SystemParam>::Item<'w, 's>: Send + Sync;
+    type Context: ReadOnlySystemParam;
 
     /// Computes the [Axis-Aligned Bounding Box](ColliderAabb) of the collider
     /// with the given position and rotation.

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -3,7 +3,7 @@
 use crate::{make_isometry, prelude::*};
 #[cfg(feature = "collider-from-mesh")]
 use bevy::render::mesh::{Indices, VertexAttributeValues};
-use bevy::{log, prelude::*};
+use bevy::{ecs::system::SystemParam, log, prelude::*};
 use collision::contact_query::UnsupportedShape;
 use itertools::Either;
 use parry::shape::{RoundShape, SharedShape, TypedShape};
@@ -439,13 +439,14 @@ impl std::fmt::Debug for Collider {
 }
 
 impl AnyCollider for Collider {
-    type Context = Collider;
+    type Context = ();
 
     fn aabb(
         &self,
         position: Vector,
         rotation: impl Into<Rotation>,
-        _context: Option<&Self::Context>,
+        _entity: Entity,
+        _context: &<Self::Context as SystemParam>::Item<'_, '_>,
     ) -> ColliderAabb {
         let aabb = self
             .shape_scaled()
@@ -456,11 +457,7 @@ impl AnyCollider for Collider {
         }
     }
 
-    fn mass_properties(
-        &self,
-        density: Scalar,
-        _context: Option<&Self::Context>,
-    ) -> ColliderMassProperties {
+    fn mass_properties(&self, density: Scalar) -> ColliderMassProperties {
         let props = self.shape_scaled().mass_properties(density);
 
         ColliderMassProperties {
@@ -488,8 +485,9 @@ impl AnyCollider for Collider {
         rotation1: impl Into<Rotation>,
         position2: Vector,
         rotation2: impl Into<Rotation>,
-        _context1: Option<&Self::Context>,
-        _context2: Option<&Self::Context>,
+        _entity1: Entity,
+        _entity2: Entity,
+        _context: &<Self::Context as SystemParam>::Item<'_, '_>,
         prediction_distance: Scalar,
     ) -> Vec<ContactManifold> {
         contact_query::contact_manifolds(

--- a/src/collision/collider/world_query.rs
+++ b/src/collision/collider/world_query.rs
@@ -23,7 +23,6 @@ pub struct ColliderQuery<C: AnyCollider> {
     pub friction: Option<&'static Friction>,
     pub restitution: Option<&'static Restitution>,
     pub shape: &'static C,
-    pub context: Option<&'static C::Context>,
 }
 
 impl<'w, C: AnyCollider> ColliderQueryItem<'w, C> {

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -16,7 +16,7 @@ use bevy::{
     ecs::{
         intern::Interned,
         schedule::{ExecutorKind, LogLevel, ScheduleBuildSettings, ScheduleLabel},
-        system::SystemParam,
+        system::{StaticSystemParam, SystemParam},
     },
     prelude::*,
 };
@@ -357,6 +357,7 @@ pub struct NarrowPhase<'w, 's, C: AnyCollider> {
     // These are scaled by the length unit.
     default_speculative_margin: Local<'s, Scalar>,
     contact_tolerance: Local<'s, Scalar>,
+    context: StaticSystemParam<'w, 's, <C as AnyCollider>::Context>,
 }
 
 impl<'w, 's, C: AnyCollider> NarrowPhase<'w, 's, C> {
@@ -542,8 +543,9 @@ impl<'w, 's, C: AnyCollider> NarrowPhase<'w, 's, C> {
             *collider1.rotation,
             position2,
             *collider2.rotation,
-            collider1.context,
-            collider2.context,
+            collider1.entity,
+            collider2.entity,
+            &self.context,
             max_distance,
         );
 

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -373,42 +373,42 @@ impl<'w, 's, C: AnyCollider> NarrowPhase<'w, 's, C> {
             *self.contact_tolerance = self.length_unit.0 * self.config.contact_tolerance;
         }
 
-        #[cfg(feature = "parallel")]
-        {
-            // TODO: Verify if `par_splat_map` is deterministic. If not, sort the constraints (and collisions).
-            broad_collision_pairs
-                .iter()
-                .par_splat_map(ComputeTaskPool::get(), None, |_i, chunks| {
-                    let mut new_collisions = Vec::<Contacts>::with_capacity(chunks.len());
+        // #[cfg(feature = "parallel")]
+        // {
+        //     // TODO: Verify if `par_splat_map` is deterministic. If not, sort the constraints (and collisions).
+        //     broad_collision_pairs
+        //         .iter()
+        //         .par_splat_map(ComputeTaskPool::get(), None, |_i, chunks| {
+        //             let mut new_collisions = Vec::<Contacts>::with_capacity(chunks.len());
 
-                    // Compute contacts for this intersection pair and generate
-                    // contact constraints for them.
-                    for &(entity1, entity2) in chunks {
-                        if let Some(contacts) =
-                            self.handle_entity_pair(entity1, entity2, delta_secs)
-                        {
-                            new_collisions.push(contacts);
-                        }
-                    }
+        //             // Compute contacts for this intersection pair and generate
+        //             // contact constraints for them.
+        //             for &(entity1, entity2) in chunks {
+        //                 if let Some(contacts) =
+        //                     self.handle_entity_pair(entity1, entity2, delta_secs)
+        //                 {
+        //                     new_collisions.push(contacts);
+        //                 }
+        //             }
 
-                    new_collisions
-                })
-                .into_iter()
-                .for_each(|new_collisions| {
-                    // Add the collisions and constraints from each chunk.
-                    self.collisions.extend(new_collisions);
-                });
-        }
-        #[cfg(not(feature = "parallel"))]
-        {
-            // Compute contacts for this intersection pair and generate
-            // contact constraints for them.
-            for &(entity1, entity2) in broad_collision_pairs {
-                if let Some(contacts) = self.handle_entity_pair(entity1, entity2, delta_secs) {
-                    self.collisions.insert_collision_pair(contacts);
-                }
+        //             new_collisions
+        //         })
+        //         .into_iter()
+        //         .for_each(|new_collisions| {
+        //             // Add the collisions and constraints from each chunk.
+        //             self.collisions.extend(new_collisions);
+        //         });
+        // }
+        // #[cfg(not(feature = "parallel"))]
+        // {
+        // Compute contacts for this intersection pair and generate
+        // contact constraints for them.
+        for &(entity1, entity2) in broad_collision_pairs {
+            if let Some(contacts) = self.handle_entity_pair(entity1, entity2, delta_secs) {
+                self.collisions.insert_collision_pair(contacts);
             }
         }
+        // }
     }
 
     /// Returns the [`Contacts`] between `entity1` and `entity2` if they are intersecting

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -373,42 +373,42 @@ impl<'w, 's, C: AnyCollider> NarrowPhase<'w, 's, C> {
             *self.contact_tolerance = self.length_unit.0 * self.config.contact_tolerance;
         }
 
-        // #[cfg(feature = "parallel")]
-        // {
-        //     // TODO: Verify if `par_splat_map` is deterministic. If not, sort the constraints (and collisions).
-        //     broad_collision_pairs
-        //         .iter()
-        //         .par_splat_map(ComputeTaskPool::get(), None, |_i, chunks| {
-        //             let mut new_collisions = Vec::<Contacts>::with_capacity(chunks.len());
+        #[cfg(feature = "parallel")]
+        {
+            // TODO: Verify if `par_splat_map` is deterministic. If not, sort the constraints (and collisions).
+            broad_collision_pairs
+                .iter()
+                .par_splat_map(ComputeTaskPool::get(), None, |_i, chunks| {
+                    let mut new_collisions = Vec::<Contacts>::with_capacity(chunks.len());
 
-        //             // Compute contacts for this intersection pair and generate
-        //             // contact constraints for them.
-        //             for &(entity1, entity2) in chunks {
-        //                 if let Some(contacts) =
-        //                     self.handle_entity_pair(entity1, entity2, delta_secs)
-        //                 {
-        //                     new_collisions.push(contacts);
-        //                 }
-        //             }
+                    // Compute contacts for this intersection pair and generate
+                    // contact constraints for them.
+                    for &(entity1, entity2) in chunks {
+                        if let Some(contacts) =
+                            self.handle_entity_pair(entity1, entity2, delta_secs)
+                        {
+                            new_collisions.push(contacts);
+                        }
+                    }
 
-        //             new_collisions
-        //         })
-        //         .into_iter()
-        //         .for_each(|new_collisions| {
-        //             // Add the collisions and constraints from each chunk.
-        //             self.collisions.extend(new_collisions);
-        //         });
-        // }
-        // #[cfg(not(feature = "parallel"))]
-        // {
-        // Compute contacts for this intersection pair and generate
-        // contact constraints for them.
-        for &(entity1, entity2) in broad_collision_pairs {
-            if let Some(contacts) = self.handle_entity_pair(entity1, entity2, delta_secs) {
-                self.collisions.insert_collision_pair(contacts);
+                    new_collisions
+                })
+                .into_iter()
+                .for_each(|new_collisions| {
+                    // Add the collisions and constraints from each chunk.
+                    self.collisions.extend(new_collisions);
+                });
+        }
+        #[cfg(not(feature = "parallel"))]
+        {
+            // Compute contacts for this intersection pair and generate
+            // contact constraints for them.
+            for &(entity1, entity2) in broad_collision_pairs {
+                if let Some(contacts) = self.handle_entity_pair(entity1, entity2, delta_secs) {
+                    self.collisions.insert_collision_pair(contacts);
+                }
             }
         }
-        // }
     }
 
     /// Returns the [`Contacts`] between `entity1` and `entity2` if they are intersecting

--- a/src/dynamics/rigid_body/mass_properties.rs
+++ b/src/dynamics/rigid_body/mass_properties.rs
@@ -251,7 +251,7 @@ impl MassPropertiesBundle {
             inverse_inertia,
             center_of_mass,
             ..
-        } = collider.mass_properties(density, None);
+        } = collider.mass_properties(density);
 
         Self {
             mass,
@@ -370,7 +370,7 @@ impl ColliderMassProperties {
     /// Because [`ColliderMassProperties`] is read-only, adding this as a component manually
     /// has no effect. The mass properties will be recomputed using the [`ColliderDensity`].
     pub fn new<C: AnyCollider>(collider: &C, density: Scalar) -> Self {
-        collider.mass_properties(density, None)
+        collider.mass_properties(density)
     }
 
     /// Transforms the center of mass by the given [`ColliderTransform`].


### PR DESCRIPTION
Makes `AnyCollider::Context` an actual, honest-to-god system param which gets injected into systems, rather than just an extra component that's queried. Also gives `AnyCollider` access to the collider entity, so that it can query itself using the context.

This skibidi PR is straight bussin yo, no cap :fire: :fire: 