### PR TITLE
Remove `AnyCollider::Context` from `aabb`

### DIFF
--- a/crates/avian2d/examples/custom_collider.rs
+++ b/crates/avian2d/examples/custom_collider.rs
@@ -1,7 +1,7 @@
 //! An example demonstrating how to make a custom collider and use it for collision detection.
 
 use avian2d::{math::*, prelude::*};
-use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
+use bevy::{ecs::system::SystemParamItem, prelude::*, sprite::MaterialMesh2dBundle};
 use examples_common_2d::ExampleCommonPlugin;
 
 fn main() {
@@ -53,13 +53,7 @@ impl CircleCollider {
 impl AnyCollider for CircleCollider {
     type Context = ();
 
-    fn aabb(
-        &self,
-        position: Vector,
-        _rotation: impl Into<Rotation>,
-        _entity: Entity,
-        _context: &Self::Context,
-    ) -> ColliderAabb {
+    fn aabb(&self, position: Vector, _rotation: impl Into<Rotation>) -> ColliderAabb {
         ColliderAabb::new(position, Vector::splat(self.radius))
     }
 
@@ -88,6 +82,7 @@ impl AnyCollider for CircleCollider {
         position2: Vector,
         rotation2: impl Into<Rotation>,
         prediction_distance: Scalar,
+        _context: &SystemParamItem<'_, '_, Self::Context>,
     ) -> Vec<ContactManifold> {
         let rotation1: Rotation = rotation1.into();
         let rotation2: Rotation = rotation2.into();

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -89,17 +89,11 @@ impl<C: ScalableCollider> Default for ColliderBackendPlugin<C> {
 
 impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
     fn build(&self, app: &mut App) {
-        #[derive(Resource)]
-        struct ContextState<C: ScalableCollider>(SystemState<C::Context>);
-
         // Register the one-shot system that is run for all removed colliders.
         if !app.world().contains_resource::<ColliderRemovalSystem>() {
             let collider_removed_id = app.world_mut().register_system(collider_removed);
             app.insert_resource(ColliderRemovalSystem(collider_removed_id));
         }
-
-        let context_state = SystemState::new(app.world_mut());
-        app.insert_resource(ContextState::<C>(context_state));
 
         let hooks = app.world_mut().register_component_hooks::<C>();
 

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -161,7 +161,7 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
                     //         so `C::Context` is unable to borrow this resource.
                     //         This does not perform any structural world changes,
                     //         so reading mutably through a read-only cell is OK.
-                    //         (We can't get a non-readonly cell from a DeferredWorld)
+                    //         (We can't get a non-readonly cell from a `DeferredWorld`)
                     unsafe { cell.get_resource_mut::<ContextState<C>>() }
                 }
                 .unwrap_or_else(|| {

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -2,7 +2,6 @@
 //!
 //! See [`ColliderBackendPlugin`].
 
-use std::any::type_name;
 use std::marker::PhantomData;
 
 use crate::{broad_phase::BroadPhaseSet, prelude::*, prepare::PrepareSet, sync::SyncConfig};
@@ -12,7 +11,7 @@ use bevy::{
     ecs::{
         intern::Interned,
         schedule::ScheduleLabel,
-        system::{StaticSystemParam, SystemId, SystemState},
+        system::{SystemId, SystemState},
     },
     prelude::*,
 };
@@ -153,31 +152,10 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
             let entity_ref = world.entity(entity);
             let collider = entity_ref.get::<C>().unwrap();
 
-            let aabb = {
-                let mut context_state = {
-                    let cell = world.as_unsafe_world_cell_readonly();
-                    // SAFETY: No other code takes a ref to this resource,
-                    //         and `ContextState` is not publicly visible,
-                    //         so `C::Context` is unable to borrow this resource.
-                    //         This does not perform any structural world changes,
-                    //         so reading mutably through a read-only cell is OK.
-                    //         (We can't get a non-readonly cell from a `DeferredWorld`)
-                    unsafe { cell.get_resource_mut::<ContextState<C>>() }
-                }
-                .unwrap_or_else(|| {
-                    panic!(
-                        "context state for `{}` was removed",
-                        type_name::<C::Context>()
-                    )
-                });
-                let context = context_state.0.get(&world);
-
-                entity_ref
-                    .get::<ColliderAabb>()
-                    .copied()
-                    .unwrap_or(collider.aabb(Vector::ZERO, Rotation::default(), entity, &context))
-            };
-
+            let aabb = entity_ref
+                .get::<ColliderAabb>()
+                .copied()
+                .unwrap_or(collider.aabb(Vector::ZERO, Rotation::default()));
             let density = entity_ref
                 .get::<ColliderDensity>()
                 .copied()
@@ -565,7 +543,6 @@ fn pretty_name(name: Option<&Name>, entity: Entity) -> String {
 fn update_aabb<C: AnyCollider>(
     mut colliders: Query<
         (
-            Entity,
             &C,
             &mut ColliderAabb,
             &Position,
@@ -592,14 +569,12 @@ fn update_aabb<C: AnyCollider>(
     narrow_phase_config: Res<NarrowPhaseConfig>,
     length_unit: Res<PhysicsLengthUnit>,
     time: Res<Time>,
-    context: StaticSystemParam<'_, '_, C::Context>,
 ) {
     let delta_secs = time.delta_seconds_adjusted();
     let default_speculative_margin = length_unit.0 * narrow_phase_config.default_speculative_margin;
     let contact_tolerance = length_unit.0 * narrow_phase_config.contact_tolerance;
 
     for (
-        entity,
         collider,
         mut aabb,
         pos,
@@ -621,7 +596,7 @@ fn update_aabb<C: AnyCollider>(
 
         if speculative_margin <= 0.0 {
             *aabb = collider
-                .aabb(pos.0, *rot, entity, &context)
+                .aabb(pos.0, *rot)
                 .grow(Vector::splat(contact_tolerance + collision_margin));
             continue;
         }
@@ -677,7 +652,7 @@ fn update_aabb<C: AnyCollider>(
         // Compute swept AABB, the space that the body would occupy if it was integrated for one frame
         // TODO: Should we expand the AABB in all directions for speculative contacts?
         *aabb = collider
-            .swept_aabb(start_pos.0, start_rot, end_pos, end_rot, entity, &context)
+            .swept_aabb(start_pos.0, start_rot, end_pos, end_rot)
             .grow(Vector::splat(collision_margin));
     }
 }

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -3,7 +3,7 @@
 use crate::{make_isometry, prelude::*};
 #[cfg(feature = "collider-from-mesh")]
 use bevy::render::mesh::{Indices, VertexAttributeValues};
-use bevy::{ecs::system::SystemParam, log, prelude::*};
+use bevy::{ecs::system::SystemParamItem, log, prelude::*};
 use collision::contact_query::UnsupportedShape;
 use itertools::Either;
 use parry::shape::{RoundShape, SharedShape, TypedShape};
@@ -441,13 +441,7 @@ impl std::fmt::Debug for Collider {
 impl AnyCollider for Collider {
     type Context = ();
 
-    fn aabb(
-        &self,
-        position: Vector,
-        rotation: impl Into<Rotation>,
-        _entity: Entity,
-        _context: &<Self::Context as SystemParam>::Item<'_, '_>,
-    ) -> ColliderAabb {
+    fn aabb(&self, position: Vector, rotation: impl Into<Rotation>) -> ColliderAabb {
         let aabb = self
             .shape_scaled()
             .compute_aabb(&make_isometry(position, rotation));
@@ -487,8 +481,8 @@ impl AnyCollider for Collider {
         rotation2: impl Into<Rotation>,
         _entity1: Entity,
         _entity2: Entity,
-        _context: &<Self::Context as SystemParam>::Item<'_, '_>,
         prediction_distance: Scalar,
+        _context: &SystemParamItem<'_, '_, Self::Context>,
     ) -> Vec<ContactManifold> {
         contact_query::contact_manifolds(
             self,

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -545,8 +545,8 @@ impl<'w, 's, C: AnyCollider> NarrowPhase<'w, 's, C> {
             *collider2.rotation,
             collider1.entity,
             collider2.entity,
-            &self.context,
             max_distance,
+            &self.context,
         );
 
         // Get the previous contacts if there are any.


### PR DESCRIPTION
It's somewhat overkill to provide `AnyCollider::aabb` and `AnyCollider::swept_aabb` with the context. In practice this isn't super useful (you can use observers to sync up the state you need to compute the AABB instead), and comes at the cost of an `unsafe` block in the add component hook, and will overcomplicate any other operation which works on `AnyCollider` (now they're responsible for also getting a `C::Context` somehow. Not impossible, but also, do we *really* need the extra complexity?)

The context is still given to `contact_manifolds`, since that's the place where this context is most useful.